### PR TITLE
fix function name of flushdb

### DIFF
--- a/src/cache/redis.mjs
+++ b/src/cache/redis.mjs
@@ -32,6 +32,6 @@ export default class extends Base {
   }
 
   async purge() {
-    await this.client.flushdb();
+    await this.client.flushDb();
   }
 }


### PR DESCRIPTION
I'm using sparql-proxy with redis backend.
On admin page, the following error occurs by executing "Purge cache".

```
(node:39) UnhandledPromiseRejectionWarning: TypeError: this.client.flushdb is not a function
    at default.purge (file:///app/src/cache/redis.mjs:35:23)
    at Socket.<anonymous> (file:///app/src/server.mjs:301:19)
    at Socket.emit (events.js:400:28)
    at Socket.emitUntyped (/app/node_modules/socket.io/dist/typed-events.js:69:22)
    at /app/node_modules/socket.io/dist/socket.js:466:39
    at processTicksAndRejections (internal/process/task_queues.js:77:11)
(Use `node --trace-warnings ...` to show where the warning was created)
```

Looking at tests of node-redis/client, the function name seem to be different. (flushdb() -> flushDb())

https://github.com/redis/node-redis/blob/3eb99dbe8378a347dd42a1ff87c89327e989443f/packages/client/lib/commands/FLUSHDB.spec.ts#L32
